### PR TITLE
Move Default Triggering

### DIFF
--- a/lib/flow/state/defaults.rb
+++ b/lib/flow/state/defaults.rb
@@ -8,12 +8,6 @@ module Flow
 
       included do
         class_attribute :_defaults, instance_writer: false, default: {}
-
-        set_callback :initialize, :after do
-          _defaults.each do |attribute, info|
-            public_send("#{attribute}=".to_sym, info.value.dup) if public_send(attribute).nil?
-          end
-        end
       end
 
       class_methods do
@@ -31,14 +25,12 @@ module Flow
       end
 
       class Value
-        def initialize(static:, &block)
+        def initialize(static: nil, &block)
           @value = (static.nil? && block_given?) ? block : static
         end
 
         def value
-          return instance_eval(&@value) if @value.respond_to?(:call)
-
-          @value
+          (@value.respond_to?(:call) ? instance_eval(&@value) : @value).dup
         end
       end
     end

--- a/lib/flow/state/options.rb
+++ b/lib/flow/state/options.rb
@@ -8,6 +8,14 @@ module Flow
 
       included do
         class_attribute :_options, instance_writer: false, default: []
+
+        set_callback :initialize, :after do
+          _options.each do |option|
+            next unless _defaults.key?(option)
+
+            public_send("#{option}=".to_sym, _defaults[option].value) if public_send(option).nil?
+          end
+        end
       end
 
       class_methods do

--- a/spec/flow/state/defaults/value_spec.rb
+++ b/spec/flow/state/defaults/value_spec.rb
@@ -37,4 +37,25 @@ RSpec.describe Flow::State::Defaults::Value, type: :subclass do
       end
     end
   end
+
+  describe "#value" do
+    subject { instance.value }
+
+    context "without a block" do
+      let(:instance) { described_class.new(static: static) }
+      let(:duplicate) { double }
+      let(:static) { double(dup: duplicate) }
+
+      it { is_expected.to eq duplicate }
+    end
+
+    context "with a block" do
+      let(:instance) { described_class.new(&block) }
+      let(:block) do
+        proc { :duplicated_object_from_block }
+      end
+
+      it { is_expected.to eq :duplicated_object_from_block }
+    end
+  end
 end

--- a/spec/flow/state/defaults_spec.rb
+++ b/spec/flow/state/defaults_spec.rb
@@ -51,24 +51,4 @@ RSpec.describe Flow::State::Defaults, type: :module do
       end
     end
   end
-
-  describe ".after_initialize" do
-    subject(:instance) { example_class.new }
-
-    let(:example_class) do
-      Class.new do
-        include Flow::State::Callbacks
-        include Flow::State::Defaults
-        include Flow::State::Core
-
-        attr_accessor :test_option1
-        attr_accessor :test_option2
-
-        define_default :test_option1, static: :default_value1
-        define_default(:test_option2) { :default_value2 }
-      end
-    end
-
-    it_behaves_like "a class with attributes having default values"
-  end
 end


### PR DESCRIPTION
Defaults can be stored centrally, but need to be used by implementors.