### PR TITLE
Prevent Double Run Bug

### DIFF
--- a/lib/flow/state/output.rb
+++ b/lib/flow/state/output.rb
@@ -14,8 +14,8 @@ module Flow
         after_validation do
           next unless validated?
 
-          _outputs.each do |output|
-            public_send("#{output}=".to_sym, _defaults[output].value) if _defaults.key?(output)
+          _outputs.each do |key|
+            public_send("#{key}=".to_sym, _defaults[key].value) if _defaults.key?(key) && public_send(key).nil?
           end
         end
       end

--- a/spec/flow/state/output_spec.rb
+++ b/spec/flow/state/output_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe Flow::State::Output, type: :module do
         expect { example_state.test_output2 = :z }.to change { example_state.test_output2 }.from(:default_value2).to(:z)
       end
     end
+
+    context "when run twice after output set" do
+      it "allows read/write of output" do
+        valid?
+
+        expect { example_state.test_output1 = :y }.to change { example_state.test_output1 }.from(:default_value1).to(:y)
+
+        # can't use subject cause it's memoized
+        expect { example_state.valid? }.not_to change { example_state.test_output1 }
+      end
+    end
   end
 
   describe "#outputs" do


### PR DESCRIPTION
This closes #97

Checking validity after the fact was forcing output back to default.