### PR TITLE
dump state writers/accessors

### DIFF
--- a/lib/flow/operation/accessors.rb
+++ b/lib/flow/operation/accessors.rb
@@ -7,8 +7,6 @@ module Flow
 
       included do
         class_attribute :_state_readers, instance_writer: false, default: []
-        class_attribute :_state_writers, instance_writer: false, default: []
-        class_attribute :_state_accessors, instance_writer: false, default: []
       end
 
       class_methods do
@@ -20,43 +18,16 @@ module Flow
           delegate name, to: :state
         end
 
-        def state_writer(name)
-          return unless _add_state_writer_tracker(name.to_sym)
-
-          delegate("#{name}=", to: :state)
-        end
-
-        def state_accessor(name)
-          state_reader name
-          state_writer name
-        end
-
         private
 
         def _add_state_reader_tracker(name)
           return false if _state_readers.include?(name)
 
-          _add_state_accessor_tracker(name) if _state_writers.include?(name)
           _state_readers << name
-        end
-
-        def _add_state_writer_tracker(name)
-          return false if _state_writers.include?(name)
-
-          _add_state_accessor_tracker(name) if _state_readers.include?(name)
-          _state_writers << name
-        end
-
-        def _add_state_accessor_tracker(name)
-          return if _state_accessors.include?(name)
-
-          _state_accessors << name
         end
 
         def inherited(base)
           base._state_readers = _state_readers.dup
-          base._state_writers = _state_writers.dup
-          base._state_accessors = _state_accessors.dup
 
           super
         end

--- a/spec/flow/operation/accessors_spec.rb
+++ b/spec/flow/operation/accessors_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Flow::Operation::Accessors, type: :module do
 
   let(:operation_class) { example_operation_class }
   let(:state_attribute) { Faker::Lorem.word.to_sym }
-  let(:state_attribute_writer) { "#{state_attribute}=".to_sym }
   let(:state_attribute_value) { Faker::Hipster.word }
 
   before do
@@ -74,80 +73,11 @@ RSpec.describe Flow::Operation::Accessors, type: :module do
     it { is_expected.to delegate_method(state_attribute).to(:state) }
 
     it_behaves_like "it has exactly one tracker variable of type", :reader
-    it_behaves_like "it has no tracker variables of type", :accessor
 
     context "when a reader has already been defined" do
       before { operation_class.__send__(:state_reader, state_attribute) }
 
       it_behaves_like "it has exactly one tracker variable of type", :reader
-      it_behaves_like "it has no tracker variables of type", :accessor
-    end
-
-    context "when a writer has already been defined" do
-      before { operation_class.__send__(:state_writer, state_attribute) }
-
-      it_behaves_like "it has exactly one tracker variable of type", :reader
-      it_behaves_like "it has exactly one tracker variable of type", :accessor
-    end
-  end
-
-  describe ".state_writer" do
-    subject(:operation) do
-      operation_class.__send__(:state_writer, state_attribute)
-      operation_class.new(state)
-    end
-
-    it_behaves_like "it inherits correctly", :state_writer, :writer
-
-    it { is_expected.to delegate_method(state_attribute_writer).to(:state).with_arguments(state_attribute_value) }
-
-    it_behaves_like "it has exactly one tracker variable of type", :writer
-    it_behaves_like "it has no tracker variables of type", :accessor
-
-    context "when a writer has already been defined" do
-      before { operation_class.__send__(:state_writer, state_attribute) }
-
-      it_behaves_like "it has exactly one tracker variable of type", :writer
-      it_behaves_like "it has no tracker variables of type", :accessor
-    end
-
-    context "when a writer has already been defined" do
-      before { operation_class.__send__(:state_reader, state_attribute) }
-
-      it_behaves_like "it has exactly one tracker variable of type", :writer
-      it_behaves_like "it has exactly one tracker variable of type", :accessor
-    end
-  end
-
-  describe ".state_accessor" do
-    subject(:operation) do
-      operation_class.__send__(:state_accessor, state_attribute)
-      operation_class.new(state)
-    end
-
-    it_behaves_like "it inherits correctly", :state_accessor, %i[reader writer accessor]
-
-    it { is_expected.to delegate_method(state_attribute).to(:state) }
-    it { is_expected.to delegate_method(state_attribute_writer).to(:state).with_arguments(state_attribute_value) }
-
-    it_behaves_like "it has exactly one tracker variable of type", :writer
-    it_behaves_like "it has exactly one tracker variable of type", :reader
-    it_behaves_like "it has exactly one tracker variable of type", :accessor
-
-    context "when a writer has already been defined" do
-      before { operation_class.__send__(:state_writer, state_attribute) }
-
-      it_behaves_like "it has exactly one tracker variable of type", :writer
-      it_behaves_like "it has exactly one tracker variable of type", :reader
-      it_behaves_like "it has exactly one tracker variable of type", :accessor
-    end
-
-    context "when a writer has already been defined" do
-      before { operation_class.__send__(:state_reader, state_attribute) }
-
-      it_behaves_like "it has exactly one tracker variable of type", :writer
-      it_behaves_like "it has exactly one tracker variable of type", :reader
-      it_behaves_like "it has exactly one tracker variable of type", :accessor
     end
   end
 end


### PR DESCRIPTION
After actually using this feature, we realized that for a given state writer `foo`, you would have to use `self.foo = something` instead of just using `foo = something` because ruby is ruby. Given this requirement, we all decided `state.foo = something` is much preferable to `self.foo = something`.