### PR TITLE
Allow triggering a Flow with a provided state instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ class ExampleFlow < ApplicationState
 end
 ```
 
+If you _already have_ an instance of a state class that you want to execute a Flow on, you can simply pass it directly to trigger:
+
+```ruby
+state_instance = ExampleState.new(...)
+
+CalculateTimetablesFlow.trigger(state_instance)
+```
+
 ### Operations
 
 An **Operation** is a service object which is executed with a **State**.

--- a/flow.gemspec
+++ b/flow.gemspec
@@ -7,7 +7,7 @@ require "flow/version"
 Gem::Specification.new do |spec|
   spec.name          = "flow"
   spec.version       = Flow::VERSION
-  spec.authors       = ["Eric Garside", "Allen Rettberg", "Jordan Minneti", "Vinod Lala"]
+  spec.authors       = ["Eric Garside", "Allen Rettberg", "Jordan Minneti", "Vinod Lala", "Andrew Cross"]
   spec.email         = ["eric.garside@freshly.com"]
 
   spec.summary       = "Write modular and reusable business logic that's understandable and maintainable."

--- a/lib/flow/flow/core.rb
+++ b/lib/flow/flow/core.rb
@@ -18,8 +18,10 @@ module Flow
       attr_reader :state
     end
 
-    def initialize(**input)
-      run_callbacks(:initialize) { @state = state_class.new(**input) }
+    def initialize(state_instance = nil, **options)
+      run_callbacks(:initialize) do
+        @state = state_instance || state_class.new(**options)
+      end
     end
   end
 end

--- a/spec/flow/core_spec.rb
+++ b/spec/flow/core_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe Flow::Core, type: :module do
 
         let(:example) { example_flow_class }
       end
+
+      context "when the argument is a state class instance" do
+        subject(:instance) { example_flow_class.new(example_state_class) }
+
+        it "assigns the argument as the state" do
+          expect(instance.state).to eq(example_state_class)
+        end
+
+        it_behaves_like "a class with callback" do
+          subject(:callback_runner) { instance }
+
+          let(:example) { example_flow_class }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Had a thought when I was looking over the docs.
What if I _already_ have an instance of a state class, and now I want to trigger a Flow using that same instance? It looks like I can call a single Operation this way already, but not a full Flow.

Here's an example use case - a rails controller action that renders some informative data, and also runs a flow if POST'd to:

```ruby
def create_new_thing
  # @state gets used in the view to show some fancy things/statistics
  @state = MyState.new(foo: params[:foo])

  if request.post?
    # our Flow uses the same info, so let's trigger it re-using the same state instance
    MyCoolFlow.trigger(@state)
  end
end
```