### PR TITLE
Discourage options and attributes on example states for operation specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ You are heavily encouraged *not* to do that. If your Operation is used by severa
 
 Instead, use the spec as a way to communicate the contract of the Operation with the next developer. By boiling out a very clean example state that only includes what is necessary for the operation, you provide clear guidance on what the Operation's minimum requirements for a state are in a very transparent way.
 
-However, the emphasis is on _minimum_ requirements. `Option`'s and `attribute`'s are therefore discouraged in example states in operation specs, as well as providing contexts for when optional input is not provided. An operation designed for use with a State using optional inputs will _always_ require those methods to be available on its state class, so example states should always use arguments for input.
+However, the emphasis is on _minimum_ requirements. `Option`s and `attribute`s are therefore discouraged in example states for operation specs, as well are contexts for when optional input is not provided. An operation designed for use with a State using optional inputs will _always_ require those methods to be available on its state class, so example states should always use arguments to define input.
 
 ```ruby
 let(:example_state_class) do

--- a/README.md
+++ b/README.md
@@ -1062,7 +1062,7 @@ The easiest and best way to test an Operation is with a unit test.
 
 Operation unit tests work best when you treat them like integration tests! (Read: **No Mocking!**)
 
-Operations are generated with the following RSPec template:
+Operations are generated with the following RSpec template:
 
 ```ruby
 # frozen_string_literal: true
@@ -1076,8 +1076,7 @@ RSpec.describe MakeTheThingDoTheStuff, type: :operation do
   let(:example_state_class) do
     Class.new(ApplicationState) do
       # argument :foo
-      # option :bar
-      # attribute :baz 
+
       # output :gaz 
     end
   end
@@ -1103,8 +1102,7 @@ In the boilerplate from the generator, there is the following snippet:
 let(:example_state_class) do
   Class.new(ApplicationState) do
     # argument :foo
-    # option :bar
-    # attribute :baz
+
     # output :gaz
   end
 end
@@ -1122,21 +1120,23 @@ You are heavily encouraged *not* to do that. If your Operation is used by severa
 
 Instead, use the spec as a way to communicate the contract of the Operation with the next developer. By boiling out a very clean example state that only includes what is necessary for the operation, you provide clear guidance on what the Operation's minimum requirements for a state are in a very transparent way.
 
+However, the emphasis is on _minimum_ requirements. `Option`'s and `attribute`'s are therefore discouraged in example states in operation specs, as well as providing contexts for when optional input is not provided. An operation designed for use with a State using optional inputs will _always_ require those methods to be available on its state class, so example states should always use arguments for input.
+
 ```ruby
 let(:example_state_class) do
   Class.new(ApplicationState) do
     argument :foo
-    option :bar
-    attribute :baz
+    argument :bar
+
     output :gaz
   end
   
   let(:state_input) do
-    { foo: foo, bar: bar }
+    { foo: foo }
   end
   
   let(:foo) { ... }
-  let(:bar) { ... }
+  let(:bar) { nil }
 end
 ```
 

--- a/lib/generators/rspec/operation/templates/operation_spec.rb.erb
+++ b/lib/generators/rspec/operation/templates/operation_spec.rb.erb
@@ -9,8 +9,7 @@ RSpec.describe <%= class_name %>, type: :operation do
   let(:example_state_class) do
     Class.new(ApplicationState) do
       # argument :foo
-      # option :bar
-      # attribute :baz
+
       # output :gaz
     end
   end


### PR DESCRIPTION
Less concise explanation:

To an operation, an optional state input IS a required argument.

It's on the state, and state spec to set it as an option. And thats because as an option on the state, we're basically saying that it defaults to `nil`.

But to an operation, exceptions would raise if its provided state didn't respond to that method, regardless of if it returns nil.

Let's say we wanted to run such an operation from the console. You could send it an openstruct as a state object, but that openstruct _has_ to have all relevant "optional" input on it, as nil or not