### PR TITLE
Add custom matchers

### DIFF
--- a/lib/flow/spec_helper/custom_matchers/have_details.rb
+++ b/lib/flow/spec_helper/custom_matchers/have_details.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Flow
+  module CustomMatchers
+    def have_details(expectation)
+      HaveDetails.new(expectation)
+    end
+
+    class HaveDetails
+      include RSpec::Matchers
+
+      def initialize(expectation)
+        if expectation.is_a? Hash
+          @expectation = OpenStruct.new(expectation)
+        else
+          @expectation = expectation
+        end
+      end
+
+      def matches?(object)
+        expect(details(object)).to eq @expectation
+      end
+
+      def description
+        "have the expected details"
+      end
+
+      private
+
+      def details(object)
+        if object.is_a? ApplicationFlow
+          object.failed_operation.operation_failure.details
+        elsif object.is_a? ApplicationOperation
+          object.operation_failure.details
+        else
+          object.details
+        end
+      end
+    end
+  end
+end

--- a/lib/flow/spec_helper/custom_matchers/have_problem_key.rb
+++ b/lib/flow/spec_helper/custom_matchers/have_problem_key.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Flow
+  module CustomMatchers
+    def have_problem_key(expectation)
+      HaveProblemKey.new(expectation)
+    end
+
+    class HaveProblemKey
+      include RSpec::Matchers
+
+      def initialize(expectation)
+        @expectation = expectation
+      end
+
+      def matches?(object)
+        expect(problem(object)).to eq @expectation
+      end
+
+      def description
+        "have the expected problem key"
+      end
+
+      private
+
+      def problem(object)
+        if object.is_a? ApplicationFlow
+          object.failed_operation.operation_failure.problem
+        elsif object.is_a? ApplicationOperation
+          object.operation_failure.problem
+        else
+          object.problem
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
```ruby
it { is_expected.to have_problem_key :the_key }
# instead of
it { expect(flow.failed_operation.operation_failure.problem).to eq :the_key }
it { expect(operation.operation_failure.problem).to eq :the_key }
it { expect(something.problem).to eq :the_key }
```
```ruby
it { is_expected.to have_details { the: :details } }
# instead of
it { expect(flow.failed_operation.operation_failure.details).to eq { the: :details } }
it { expect(operation.operation_failure.details).to eq { the: :details } }
it { expect(something.details).to eq { the: :details } }
```