### PR TITLE
fixes #211: updates documentation syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ class CreateCharge < ApplicationOperation
   private
 
   def payment_method
-    payment_method.present? payment_method : user.default_payment_method
+    payment_method.present? ? payment_method : user.default_payment_method
   end
 end
 ```


### PR DESCRIPTION
This PR fixes what I think is a small typo in the README where the `?` is left out of a ternary shorthand declaration.  Obviously not a critical issue, but opted to take care of it.